### PR TITLE
Update index.md to fix table of content

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@
     - [External](#external-1)
 - [Lists](#lists)
   - [Ordered](#ordered)
-  - [Unorderly](#unorderly)
+  - [Unordered](#unordered)
 - [Tables](#tables)
 
 <!-- Example of paragraph of text with line break -->


### PR DESCRIPTION
Odwołanie do tytułu rozdziału musi podawać dokładnie taki adres (anchor), jaki powstał z tytułu rozdziału: tutaj to #unordered
